### PR TITLE
Custom mount commands and option split

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,4 +36,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with unittest
       run: |
-        unittest discover
+        python -m unittest discover

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ build/
 
 # IDE configuration
 .vscode
+
+htmlcov/
+.coverage

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ volumes:
   nfs:
     driver: easyfuse
     driver_opts:
-      o: IdentityFile=$PWD/my-secret.key,uid=1000,gid=1000,users,idmap=user,noatime,allow_other,_netdev,reconnect,rw
+      opts: IdentityFile=$PWD/my-secret.key,uid=1000,gid=1000,users,idmap=user,noatime,allow_other,_netdev,reconnect,rw
       device: "sshfs#testuser@localhost:testdir"
 ```
 
@@ -180,7 +180,7 @@ examples$
 ### Verify with a regular named volume
 
 ```
-examples$ docker volume create -d easyfuse -o "o=IdentityFile=$PWD/mini-sshfs/.keys/ssh_user_ed25519_key,UserKnownHostsFile=$PWD/mini-sshfs/known_hosts,port=2022,uid=1000,gid=1000,users,idmap=user,noatime,allow_other,_netdev,reconnect,rw" -o "device=sshfs#$USER@localhost:$PWD/test" my-volume
+examples$ docker volume create -d easyfuse -o "opts=IdentityFile=$PWD/mini-sshfs/.keys/ssh_user_ed25519_key,UserKnownHostsFile=$PWD/mini-sshfs/known_hosts,port=2022,uid=1000,gid=1000,users,idmap=user,noatime,allow_other,_netdev,reconnect,rw" -o "device=sshfs#$USER@localhost:$PWD/test" my-volume
 my-volume
 
 examples$ docker run --rm -it -v my-volume:/my-volume busybox ls /my-volume -lah
@@ -210,7 +210,7 @@ volumes:
   nas:
     driver: easyfuse
     driver_opts:
-      o: IdentityFile=$PWD/mini-sshfs/.keys/ssh_user_ed25519_key,UserKnownHostsFile=$PWD/mini-sshfs/known_hosts,Port=2022,uid=1000,gid=1000,users,idmap=user,noatime,allow_other,_netdev,reconnect,rw
+      opts: IdentityFile=$PWD/mini-sshfs/.keys/ssh_user_ed25519_key,UserKnownHostsFile=$PWD/mini-sshfs/known_hosts,Port=2022,uid=1000,gid=1000,users,idmap=user,noatime,allow_other,_netdev,reconnect,rw
       device: "sshfs#$USER@localhost:$PWD/test"
 
 examples$ docker-compose up

--- a/easyfuse/Handler.py
+++ b/easyfuse/Handler.py
@@ -21,6 +21,7 @@ import json
 import logging
 
 from .Driver import Driver, DriverError
+from .parse_command import ParserError
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +75,7 @@ class Handler:
             })
         except KeyError as e:
             return jsonify({"Err": f"Missing option: {e}"}, status=400)
-        except DriverError as e:
+        except (DriverError, ParserError) as e:
             return jsonify({"Err": str(e)}, status=400)
 
     async def handle_volumedriver_path(self, request: aiohttp.web.Request):
@@ -101,7 +102,7 @@ class Handler:
             return jsonify({"Err": ""})
         except KeyError as e:
             return jsonify({"Err": f"Missing option: {e}"}, status=400)
-        except DriverError as e:
+        except (DriverError, ParserError) as e:
             return jsonify({"Err": str(e)}, status=400)
 
     async def handle_volumedriver_get(self, request: aiohttp.web.Request):

--- a/easyfuse/parse_command.py
+++ b/easyfuse/parse_command.py
@@ -1,0 +1,76 @@
+'''
+easyfuse - simple FUSE volume driver for Docker
+Copyright (C) 2020  Marcin Słowik
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+'''
+
+import itertools
+import os
+import re
+import shlex
+
+# Can be removed >= Python 3.9
+from typing import List, Union, Mapping
+
+MappingType = Mapping[str, str]
+
+
+class ParserError(Exception):
+    pass
+
+
+def _append_mapping(lst, token, mapping):
+    value = mapping.get(token, '')
+    if '\n' in value:
+        value = list(value.split('\n'))
+    elif value:
+        value = [value]
+    else:
+        value = []
+    lst.append(value)
+
+
+def parse_command(command: str, mapping: MappingType):
+    parser = shlex.shlex(command, punctuation_chars=True)
+    cmd: List[List[str]] = []
+    sub: List[List[str]] = None
+    while True:
+        token = parser.get_token()
+        if token == parser.eof:
+            break
+        elif token == ']':
+            if sub is None:
+                raise ParserError("misplaced ]")
+            cmd += itertools.product(*sub)
+            sub = None
+        elif token == '[':
+            if sub is not None:
+                raise ParserError("nested [")
+            sub = []
+        elif token == '{':
+            varname = parser.get_token()
+            if varname == parser.eof:
+                raise ParserError("invalid {variable} token")
+            token = parser.get_token()
+            if token != '}':
+                raise ParserError("missing }")
+            _append_mapping(sub if sub is not None else cmd, varname, mapping)
+        elif sub is not None:
+            sub.append([token])
+        else:
+            cmd.append([token])
+    if sub is not None:
+        raise ParserError("unterminated [")
+    return [y for x in cmd for y in x]

--- a/easyfuse/systemd_setup.py
+++ b/easyfuse/systemd_setup.py
@@ -44,7 +44,8 @@ if __name__ == '__main__':
         choices=['local', 'global', 'venv'],
         help="choose which context should be used to call the module")
     argparser.add_argument(
-        '-p', '--path',
+        '-p',
+        '--path',
         type=pathlib.Path,
         default=pathlib.Path('/etc/systemd/system'),
         help="choose where to store systemd unit files; see systemd.unit(5); "

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -11,5 +11,5 @@ volumes:
   nas:
     driver: easyfuse
     driver_opts:
-      o: IdentityFile=$PWD/mini-sshfs/.keys/ssh_user_ed25519_key,UserKnownHostsFile=$PWD/mini-sshfs/known_hosts,Port=2022,uid=1000,gid=1000,users,idmap=user,noatime,allow_other,_netdev,reconnect,rw
+      opts: IdentityFile=$PWD/mini-sshfs/.keys/ssh_user_ed25519_key,UserKnownHostsFile=$PWD/mini-sshfs/known_hosts,Port=2022,uid=1000,gid=1000,users,idmap=user,noatime,allow_other,_netdev,reconnect,rw
       device: "sshfs#$USER@localhost:$PWD/test"

--- a/examples/mini-sshfs/sshd_config.template
+++ b/examples/mini-sshfs/sshd_config.template
@@ -8,7 +8,7 @@ HostKey $HERE/.keys/ssh_host_rsa_key
 HostKey $HERE/.keys/ssh_host_ecdsa_key
 HostKey $HERE/.keys/ssh_host_ed25519_key
 
-AuthorizedKeysFile=$HERE/authorized_keys
-AllowUsers=$USER
+AuthorizedKeysFile $HERE/authorized_keys
+AllowUsers $USER
 
 LogLevel DEBUG3

--- a/examples/split-opts.yml
+++ b/examples/split-opts.yml
@@ -1,0 +1,66 @@
+version: '3.4'
+
+services:
+  mytest:
+    image: alpine
+    volumes:
+      - 'nas1:/nas1:rw'
+      - 'nas2:/nas2:rw'
+      - 'nas3:/nas3:rw'
+    command: [sh, -c, 'touch /nas1/test1; ls -lah /nas1; touch /nas2/test2; ls -lah /nas2; touch /nas3/test3; ls -lah /nas3;']
+
+volumes:
+  nas1:
+    driver: easyfuse
+    driver_opts:
+      opts: |
+        IdentityFile=$PWD/mini-sshfs/.keys/ssh_user_ed25519_key
+        UserKnownHostsFile=$PWD/mini-sshfs/known_hosts
+        Port=2022
+        uid=1001
+        gid=1001
+        users
+        idmap=user
+        noatime
+        allow_other
+        _netdev
+        reconnect
+        rw
+      device: "sshfs#$USER@localhost:$PWD/test"
+      
+  nas2:
+    driver: easyfuse
+    driver_opts:
+      driver: fuse
+      opts: |
+        IdentityFile=$PWD/mini-sshfs/.keys/ssh_user_ed25519_key
+        UserKnownHostsFile=$PWD/mini-sshfs/known_hosts
+        Port=2022
+        uid=1002
+        gid=1002
+        users
+        idmap=user
+        noatime
+        allow_other
+        _netdev
+        reconnect
+        rw
+      device: "sshfs#$USER@localhost:$PWD/test"
+      
+  nas3:
+    driver: easyfuse
+    driver_opts:
+      mount_command: "sshfs [-o {opts}] {device} {target}"
+      unmount_command: "fusermount -u {target}"
+      opts: |
+        IdentityFile=$PWD/mini-sshfs/.keys/ssh_user_ed25519_key
+        UserKnownHostsFile=$PWD/mini-sshfs/known_hosts
+        Port=2022
+        uid=1002
+        gid=1002
+        idmap=user
+        noatime
+        allow_other
+        reconnect
+        rw
+      device: "$USER@localhost:$PWD/test"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 aiohttp
+dataclasses; python_version < '3.7'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name='docker-volume-easyfuse',
-    version='0.2.1',
+    version='0.3.0',
     description='simple FUSE volume driver for Docker',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -16,8 +16,8 @@ setup(
     author="Marcin Słowik",
     author_email="me@marandil.pl",
     packages=find_packages(),
-    zip_safe=False,
-    install_requires=['aiohttp'],
+    zip_safe=True,
+    install_requires=['aiohttp', "dataclasses;python_version<'3.7'"],
     python_requires='>=3.6',
     classifiers=[
         "Development Status :: 3 - Alpha",
@@ -29,9 +29,7 @@ setup(
     include_package_data=True,
     package_data={'easyfuse': ['systemd/*']},
     data_files=[('share/easyfuse/systemd', [
-        'systemd/easyfuse.socket',
-        'systemd/easyfuse.service',
-        'systemd/easyfuse.service.dev',
-        'systemd/easyfuse.service.venv'
+        'systemd/easyfuse.socket', 'systemd/easyfuse.service',
+        'systemd/easyfuse.service.dev', 'systemd/easyfuse.service.venv'
     ])],
 )

--- a/tests/TestDriver.py
+++ b/tests/TestDriver.py
@@ -1,0 +1,115 @@
+import asyncio
+import json
+import pathlib
+import shlex
+import shutil
+import sys
+import unittest
+
+from argparse import Namespace
+from easyfuse.Driver import DriverError, Driver
+
+
+class TestDriver(unittest.TestCase):
+    def setUp(self):
+        here = pathlib.Path(__file__).parent.resolve()
+        self.testdir = here / '.test'
+        self.mntpt = self.testdir / 'mntpt'
+        self.mntdb = self.testdir / 'mntdb.json'
+        opts = Namespace(mntpt=str(self.mntpt), mntdb=str(self.mntdb))
+        self.driver = Driver(opts)
+        self.loop = asyncio.get_event_loop()
+
+    def tearDown(self):
+        shutil.rmtree(self.testdir)
+
+    def test_get_path_for(self):
+        self.assertEqual(str(self.mntpt / 'vol'),
+                         self.driver.get_path_for('vol'))
+
+    def test_volume_create(self):
+        self.loop.run_until_complete(self._test_volume_create())
+
+    async def _test_volume_create(self):
+        await self.driver.volume_create('vol', {
+            'device': '~device',
+            'opts': '~opts'
+        })
+        with self.mntdb.open('r') as f:
+            d = json.load(f)
+        self.assertIn('vol', d)
+        self.assertIn('opts', d['vol'])
+        self.assertIn('name', d['vol'])
+        self.assertIn('instances', d['vol'])
+        self.assertIn('is_mounted', d['vol'])
+
+        self.assertIn('driver', d['vol']['opts'])
+        self.assertIn('device', d['vol']['opts'])
+        self.assertIn('opts', d['vol']['opts'])
+        self.assertEqual(d['vol']['opts']['driver'], 'fuse')
+        self.assertEqual(d['vol']['opts']['device'], '~device')
+        self.assertEqual(d['vol']['opts']['opts'], '~opts')
+
+        self.assertEqual(d['vol']['name'], 'vol')
+        self.assertEqual(d['vol']['instances'], [])
+        self.assertEqual(d['vol']['is_mounted'], False)
+
+    def test_volume_remove(self):
+        self.loop.run_until_complete(self._test_volume_remove())
+
+    async def _test_volume_remove(self):
+        await self.driver.volume_create('vol', {
+            'device': '~device',
+            'opts': '~opts'
+        })
+        await self.driver.volume_remove('vol')
+        with self.mntdb.open('r') as f:
+            d = json.load(f)
+        self.assertFalse(d)
+
+    def test_volume_mount_unmount(self):
+        self.loop.run_until_complete(self._test_volume_mount_unmount())
+
+    async def _test_volume_mount_unmount(self):
+        # we use python as mount command, with the following command as device
+        # to dump the remaining arguments to file
+        dc = 'import sys; open(sys.argv[1], "w").write(repr(sys.argv[2:]))'
+        await self.driver.volume_create('vol', {'device': dc, 'opts': '~opts'})
+        with self.mntdb.open('r') as f:
+            d = json.load(f)
+        dropfile_a = self.testdir / "drop-a"
+        d['vol']['opts']['mount_command'] = (
+            f'{sys.executable} -c {{device}} '
+            f'{str(dropfile_a)} {{target}} {{opts}} {{driver}}')
+        dropfile_b = self.testdir / "drop-b"
+        d['vol']['opts']['unmount_command'] = (
+            f'{sys.executable} -c {{device}} '
+            f'{str(dropfile_b)} {{target}} {{opts}} {{driver}}')
+        with self.mntdb.open('w') as f:
+            json.dump(d, f)
+        args = [str(self.mntpt / 'vol'), "~opts", "fuse"]
+        await self.driver.volume_mount('vol', 'ffffffffffffffff')
+        self.assertTrue(await self.driver.is_mounted('vol'))
+        await self.driver.volume_unmount('vol', 'ffffffffffffffff')
+        self.assertFalse(await self.driver.is_mounted('vol'))
+        with dropfile_a.open('r') as f:
+            self.assertEqual(f.read(), repr(args))
+        with dropfile_b.open('r') as f:
+            self.assertEqual(f.read(), repr(args))
+
+    def test_volume_missing_errors(self):
+        self.loop.run_until_complete(self._test_volume_missing_errors())
+
+    async def _test_volume_missing_errors(self):
+        with self.assertRaises(DriverError) as ctx:
+            await self.driver.is_mounted('vol')
+        self.assertEqual(str(ctx.exception), 'Volume vol not found.')
+        with self.assertRaises(DriverError) as ctx:
+            await self.driver.volume_remove('vol')
+        self.assertEqual(str(ctx.exception), 'Volume vol not found.')
+        with self.assertRaises(DriverError) as ctx:
+            await self.driver.volume_mount('vol', 'ffff')
+        self.assertEqual(str(ctx.exception), 'Volume vol not found.')
+        with self.assertRaises(DriverError) as ctx:
+            await self.driver.volume_unmount('vol', 'ffff')
+        self.assertEqual(str(ctx.exception), 'Volume vol not found.')

--- a/tests/TestParseCommand.py
+++ b/tests/TestParseCommand.py
@@ -1,0 +1,60 @@
+import unittest
+
+from easyfuse.parse_command import parse_command, ParserError
+
+
+class TestParseCommand(unittest.TestCase):
+    def test_parse_plain(self):
+        cmd = parse_command('command argument argument', {})
+        self.assertEqual(cmd, ['command', 'argument', 'argument'])
+
+    def test_parse_mapping(self):
+        cmd = parse_command('command {argument1} {argument2}', {
+            'argument1': 'value1',
+            'argument2': 'value2'
+        })
+        self.assertEqual(cmd, ['command', 'value1', 'value2'])
+
+    def test_parse_optional(self):
+        cmd = parse_command('command [{argument1}] {argument2}', {
+            'argument1': 'value1',
+            'argument2': 'value2'
+        })
+        self.assertEqual(cmd, ['command', 'value1', 'value2'])
+        cmd = parse_command('command [{argument1}] {argument2}', {
+            'argument1': '',
+            'argument2': 'value2'
+        })
+        self.assertEqual(cmd, ['command', 'value2'])
+        cmd = parse_command('command [{argument1}] {argument2}',
+                            {'argument2': 'value2'})
+        self.assertEqual(cmd, ['command', 'value2'])
+
+    def test_parse_unroll(self):
+        cmd = parse_command('command [tag {argument1}] {argument2}', {
+            'argument1': 'value1\nvalue2',
+            'argument2': 'value3'
+        })
+        self.assertEqual(
+            cmd, ['command', 'tag', 'value1', 'tag', 'value2', 'value3'])
+
+    def test_errors(self):
+        with self.assertRaises(ParserError) as ctx:
+            parse_command('cmd [tag', {})
+        self.assertEqual(str(ctx.exception), 'unterminated [')
+        with self.assertRaises(ParserError) as ctx:
+            parse_command('cmd tag]', {})
+        self.assertEqual(str(ctx.exception), 'misplaced ]')
+        with self.assertRaises(ParserError) as ctx:
+            parse_command('cmd [tag [tag]]', {})
+        self.assertEqual(str(ctx.exception), 'nested [')
+        with self.assertRaises(ParserError) as ctx:
+            parse_command('cmd {tag tag}', {})
+        self.assertEqual(str(ctx.exception), 'missing }')
+        with self.assertRaises(ParserError) as ctx:
+            parse_command('cmd {', {})
+        self.assertEqual(str(ctx.exception), 'invalid {variable} token')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+from .TestDriver import TestDriver
+from .TestParseCommand import TestParseCommand

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,0 +1,7 @@
+import unittest
+
+from .TestDriver import TestDriver
+from .TestParseCommand import TestParseCommand
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* rename `o` to `opts` in `driver_opts`
* add custom commands (and custom command parsing) for mount/unmount
* cleanup volume_mount and volume_unmount with a generic `parse_command` function
* refactor `MountDatabase` to directly use custom `JSONEncoder` and `JSONDecoder`
* add basic tests for `Driver` class and `parse_command` functions.